### PR TITLE
Remove the response types and fix typing init.

### DIFF
--- a/src/ts/simpleAllies.ts
+++ b/src/ts/simpleAllies.ts
@@ -135,33 +135,14 @@ export interface RoomRequest {
 }
 
 export interface AllyRequests {
-    resource?: ResourceRequest[]
-    defense?: DefenseRequest[]
-    attack?: AttackRequest[]
-    player?: PlayerRequest[]
-    work?: WorkRequest[]
-    funnel?: FunnelRequest[];
+    resource: ResourceRequest[]
+    defense: DefenseRequest[]
+    attack: AttackRequest[]
+    player: PlayerRequest[]
+    work: WorkRequest[]
+    funnel: FunnelRequest[];
     econ?: EconRequest
-    room?: RoomRequest[]
-}
-
-interface DefenseResponse {
-    roomName: string
-}
-
-interface AttackResponse {
-    roomName: string
-}
-
-interface WorkResponse {
-    roomName: string
-}
-
-interface AllyResponses {
-    // resource?: ResourceRequest[]
-    defense?: DefenseResponse[]
-    attack?: AttackResponse[]
-    work?: WorkResponse[]
+    room: RoomRequest[]
 }
 
 /**
@@ -174,10 +155,22 @@ export interface SimpleAlliesSegment {
     requests: AllyRequests
 }
 
+const emptyRequest: AllyRequests = {
+    resource: [],
+    defense: [],
+    attack: [],
+    player: [],
+    work: [],
+    funnel: [],
+    room: [],
+}
+
+
 class SimpleAllies {
-    myRequests: AllyRequests = {}
-    myResponses: AllyResponses = {}
-    allySegmentData: SimpleAlliesSegment
+    myRequests: AllyRequests = {...emptyRequest}
+    // Partial since we can't trust others to not omit fields
+    // we want to make sure we check their existance
+    allySegmentData: Partial<SimpleAlliesSegment> = {}
     currentAlly: string
 
     /**
@@ -193,11 +186,6 @@ class SimpleAllies {
             work: [],
             funnel: [],
             room: [],
-        }
-        this.myResponses = {
-            defense: [],
-            attack: [],
-            work: [],
         }
 
         this.readAllySegment()


### PR DESCRIPTION
The response types are only defined in the TS but not the JS. They don't belong in this code. They can be an example of how someone would extend this to track their own responses but should not be included here as they are not part of the public segment interface this is trying to communicate.

Also `AllyRequests` should not have all the lists be `?`. If it does then the functions using it need guardslike 

```typescript
    requestResource(args: ResourceRequest) {
        if(!this.myRequests.resource){
            this.myRequests.resource = [args]
        }
        else{
            this.myRequests.resource.push(args)
       }
    }
```    
to pass type safety. Instead of adding that everywhere we can just make them non optional and fix the init.