### PR TITLE
Classify and cleanups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@rollup/plugin-commonjs": "^25.0.7",
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-typescript": "^11.1.5",
+                "@total-typescript/ts-reset": "^0.5.1",
                 "@types/node": "^20.8.0",
                 "@types/screeps": "^3.3.7",
                 "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -319,6 +320,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@total-typescript/ts-reset": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.5.1.tgz",
+            "integrity": "sha512-AqlrT8YA1o7Ff5wPfMOL0pvL+1X+sw60NN6CcOCqs658emD6RfiXhF7Gu9QcfKBH7ELY2nInLhKSCWVoNL70MQ==",
+            "dev": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.5",
+        "@total-typescript/ts-reset": "^0.5.1",
         "@types/node": "^20.8.0",
         "@types/screeps": "^3.3.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/src/exampleBot.ts
+++ b/src/exampleBot.ts
@@ -1,4 +1,6 @@
-import { simpleAllies } from './simpleAllies';
+import { SimpleAllies } from './simpleAllies';
+
+const simpleAllies = new SimpleAllies();
 
 /**
  * Example bot loop

--- a/src/exampleBot.ts
+++ b/src/exampleBot.ts
@@ -25,12 +25,14 @@ export function loop() {
  * Example of responding to ally defense requests
  */
 function respondToAllyDefenseRequests() {
-    if (!simpleAllies.allySegmentData) return;
+    for (const playerName in simpleAllies.allySegments) {
+        const segment = simpleAllies.allySegments[playerName];
 
-    // Send creeps to defend rooms
-    for (const request of simpleAllies.allySegmentData.requests.defense) {
-        console.log('[simpleAllies] Respond to defense request', JSON.stringify(request));
-        // ...
+        // Send creeps to defend rooms
+        for (const request of segment.requests.defense) {
+            console.log('[simpleAllies] Respond to defense request', JSON.stringify(request));
+            // ...
+        }
     }
 }
 
@@ -38,12 +40,14 @@ function respondToAllyDefenseRequests() {
  * Example of responding to ally resource requests
  */
 function respondToAllyResourceRequests() {
-    if (!simpleAllies.allySegmentData) return;
+    for (const playerName in simpleAllies.allySegments) {
+        const segment = simpleAllies.allySegments[playerName];
 
-    // Send resources to rooms
-    for (const request of simpleAllies.allySegmentData.requests.resource) {
-        console.log('[simpleAllies] Respond to resource request', JSON.stringify(request));
-        // ...
+        // Send resources to rooms
+        for (const request of segment.requests.resource) {
+            console.log('[simpleAllies] Respond to resource request', JSON.stringify(request));
+            // ...
+        }
     }
 }
 

--- a/src/reset.d.ts
+++ b/src/reset.d.ts
@@ -1,0 +1,2 @@
+// Do not add any other lines of code to this file!
+import '@total-typescript/ts-reset';

--- a/src/simpleAllies.ts
+++ b/src/simpleAllies.ts
@@ -8,7 +8,13 @@ export const allies = ['Player1', 'Player2', 'Player3'];
 /**
  * This segment ID used for team communication
  */
-export const allySegmentID = 90;
+export const SIMPLE_ALLIES_SEGMENT_ID = 90;
+
+/**
+ * Max number of segments openable at once
+ * This isn't in the docs for some reason, so we need to add it
+ */
+const MAX_OPEN_SEGMENTS = 10;
 
 /**
  * Represents the goal type enum for javascript
@@ -99,7 +105,7 @@ export class SimpleAllies {
 
         // Make a request to read the data of the next ally in the list, for next tick
         const nextAllyName = allies[(Game.time + 1) % allies.length];
-        RawMemory.setActiveForeignSegment(nextAllyName, allySegmentID);
+        RawMemory.setActiveForeignSegment(nextAllyName, SIMPLE_ALLIES_SEGMENT_ID);
 
         // Maybe the code didn't run last tick, so we didn't set a new read segment
         if (!RawMemory.foreignSegment) return;
@@ -109,7 +115,7 @@ export class SimpleAllies {
         try {
             return JSON.parse(RawMemory.foreignSegment.data) as Types.SimpleAlliesSegment;
         } catch (e) {
-            this.log(`Error reading ${this.currentAlly} segment ${allySegmentID}`);
+            this.log(`Error reading ${this.currentAlly} segment ${SIMPLE_ALLIES_SEGMENT_ID}`);
         }
     }
 
@@ -117,17 +123,17 @@ export class SimpleAllies {
      * To call after requests have been made, to assign requests to the next ally
      */
     public endRun() {
-        if (Object.keys(RawMemory.segments).length >= 10) {
+        if (Object.keys(RawMemory.segments).length >= MAX_OPEN_SEGMENTS) {
             this.log('Too many segments open');
             return;
         }
 
-        RawMemory.segments[allySegmentID] = JSON.stringify({
+        RawMemory.segments[SIMPLE_ALLIES_SEGMENT_ID] = JSON.stringify({
             requests: this.myRequests,
             econ: this.myEconInfo,
             updated: Game.time,
         });
-        RawMemory.setPublicSegments([allySegmentID]);
+        RawMemory.setPublicSegments([SIMPLE_ALLIES_SEGMENT_ID]);
     }
 
     /**

--- a/src/simpleAllies.ts
+++ b/src/simpleAllies.ts
@@ -30,7 +30,7 @@ export const EWorkType = {
 /**
  * Simple allies class manages ally requests
  */
-class SimpleAllies {
+export class SimpleAllies {
     /**
      * State
      */
@@ -216,5 +216,3 @@ class SimpleAllies {
         this.myEconInfo = args;
     }
 }
-
-export const simpleAllies = new SimpleAllies();

--- a/src/simpleAllies.ts
+++ b/src/simpleAllies.ts
@@ -46,6 +46,23 @@ export class SimpleAllies {
     private myEconInfo?: Types.EconInfo;
     public allySegmentData?: Types.SimpleAlliesSegment;
     public currentAlly?: string;
+    private _debug: boolean;
+
+    constructor(options?: { debug?: boolean }) {
+        this._debug = options?.debug ?? false;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private log(...args: any[]) {
+        console.log('[SimpleAllies]', ...args);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private debug(...args: any[]) {
+        if (!this._debug) return;
+
+        this.log(...args);
+    }
 
     /**
      * To call before any requests are made or responded to.
@@ -74,7 +91,7 @@ export class SimpleAllies {
      */
     private readAllySegment() {
         if (!allies.length) {
-            console.log('[simpleAllies] You have no allies');
+            this.log('You have no allies');
             return;
         }
 
@@ -92,9 +109,7 @@ export class SimpleAllies {
         try {
             return JSON.parse(RawMemory.foreignSegment.data) as Types.SimpleAlliesSegment;
         } catch (e) {
-            console.log(
-                `[simpleAllies] Error reading ${this.currentAlly} segment ${allySegmentID}`
-            );
+            this.log(`Error reading ${this.currentAlly} segment ${allySegmentID}`);
         }
     }
 
@@ -103,7 +118,7 @@ export class SimpleAllies {
      */
     public endRun() {
         if (Object.keys(RawMemory.segments).length >= 10) {
-            console.log('[simpleAllies] Too many segments open');
+            this.log('Too many segments open');
             return;
         }
 

--- a/src/simpleAllies.ts
+++ b/src/simpleAllies.ts
@@ -1,7 +1,7 @@
 import * as Types from './types';
 
 /**
- * This segment ID used for team communication
+ * The segment ID used for communication
  */
 export const SIMPLE_ALLIES_SEGMENT_ID = 90;
 


### PR DESCRIPTION
This comes from me trying to integrate it in OM, since it has its own segment manager, handles instantiation, etc.

The big changes are that any sort of segment access goes through protected methods (so supposedly you just subclass it and provide your own stuff), and loads the segments in a round-robin, so you can always look at the last state you saw from an ally. The rest is mostly style cleanups.

Better look at the individual commits. I can definitely slice and dice stuff if it feels not appropriate (I realize writing this that caching all that stuff makes it hard on the heap usage, for example).